### PR TITLE
Remove duplicate export of utcSecond

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,6 @@ export {
   week as timeWeek,
   month as timeMonth,
   year as timeYear,
-  utcSecond,
   utcMinute,
   utcHour,
   utcDay,


### PR DESCRIPTION
Closes #12.

Manually tested by modifying local copy under `node_modules` and running Rollup. It bundles fine after this change.