### PR TITLE
Fix typo in offset tests

### DIFF
--- a/test/day-test.js
+++ b/test/day-test.js
@@ -103,7 +103,7 @@ tape("timeDay.offset(date) is an alias for timeDay.offset(date, 1)", function(te
 
 tape("timeDay.offset(date, step) does not modify the passed-in date", function(test) {
   var d = date.local(2010, 11, 31, 23, 59, 59, 999);
-  time.timeDay.offset(date, +1);
+  time.timeDay.offset(d, +1);
   test.deepEqual(d, date.local(2010, 11, 31, 23, 59, 59, 999));
   test.end();
 });

--- a/test/month-test.js
+++ b/test/month-test.js
@@ -166,7 +166,7 @@ tape("timeMonth.offset(date) is an alias for timeMonth.offset(date, 1)", functio
 
 tape("timeMonth.offset(date, step) does not modify the passed-in date", function(test) {
   var d = date.local(2010, 11, 31, 23, 59, 59, 999);
-  time.timeMonth.offset(date, +1);
+  time.timeMonth.offset(d, +1);
   test.deepEqual(d, date.local(2010, 11, 31, 23, 59, 59, 999));
   test.end();
 });

--- a/test/utcMonth-test.js
+++ b/test/utcMonth-test.js
@@ -86,7 +86,7 @@ tape("utcMonth.offset(date) is an alias for utcMonth.offset(date, 1)", function(
 
 tape("utcMonth.offset(date, step) does not modify the passed-in date", function(test) {
   var d = date.utc(2010, 11, 31, 23, 59, 59, 999);
-  time.utcMonth.offset(date, +1);
+  time.utcMonth.offset(d, +1);
   test.deepEqual(d, date.utc(2010, 11, 31, 23, 59, 59, 999));
   test.end();
 });


### PR DESCRIPTION
I noticed that some `.offset()` tests were trying to increment the mock `date` helper rather than a real `Date` object, and were passing by coincidence. This fixes them to make sure they're testing the right things.